### PR TITLE
chore: bump runtime to gnome 48

### DIFF
--- a/io.github.dvlv.boxbuddyrs.json
+++ b/io.github.dvlv.boxbuddyrs.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.dvlv.boxbuddyrs",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
the new gtk version happens to fix the super annoying bug with the huge cursor on KDE